### PR TITLE
• refactor alert method to use keyword arguments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rmq_alerts (0.2)
+    rmq_alerts (1.0)
       ruby_motion_query (>= 0.9.0)
 
 GEM
@@ -16,3 +16,6 @@ PLATFORMS
 DEPENDENCIES
   rake
   rmq_alerts!
+
+BUNDLED WITH
+   1.16.4

--- a/lib/project/rmq_alerts.rb
+++ b/lib/project/rmq_alerts.rb
@@ -4,18 +4,18 @@ module RubyMotionQuery
     # The first two parameters are required (title and message).
     # It returns an rmq object.
     # @return [RMQ]
-    def alert(title, message, cancel_button = 'OK', other_buttons = [], delegate = nil, view_style = UIAlertViewStyleDefault)
+    def alert(title, options = {})
       # TODO UIAlertView is deprecated in iOS 8. Should use UIAlertController for the future.
       alert_view = UIAlertView.alloc.initWithTitle(
         title,
-        message: message,
-        delegate: delegate,
-        cancelButtonTitle: cancel_button,
+        message: options.fetch(:message, nil),
+        delegate: options.fetch(:delegate, nil),
+        cancelButtonTitle: options.fetch(:cancel_button, 'OK'),
         otherButtonTitles: nil
       )
-      Array(other_buttons).each { |button| alert_view.addButtonWithTitle(button) }
+      Array(options.fetch(:other_buttons, [])).each { |button| alert_view.addButtonWithTitle(button) }
 
-      alert_view.alertViewStyle = view_style
+      alert_view.alertViewStyle = options.fetch(:view_style, UIAlertViewStyleDefault)
 
       alert_view.show
       rmq(alert_view)

--- a/rmq_alerts.gemspec
+++ b/rmq_alerts.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-VERSION = "0.2"
+VERSION = '1.0'
 
 Gem::Specification.new do |spec|
   spec.name          = "rmq_alerts"
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'ruby_motion_query', '>= 0.9.0'
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
• refactor alert method to use keyword arguments instead of positional arguments
• this makes it simpler to define the cancel button (and other buttons) without having to specify a message